### PR TITLE
Clean up warnings and bug with no pre-existing keys

### DIFF
--- a/lib/chef/provider/google_key_pair.rb
+++ b/lib/chef/provider/google_key_pair.rb
@@ -4,6 +4,8 @@ require "chef/resource/google_key_pair"
 require "retryable"
 
 class Chef::Provider::GoogleKeyPair < Chef::Provider::LWRPBase
+  provides :google_key_pair
+
   use_inline_resources
 
   # TODO make sure we can take relative paths - where do we get base path from then?

--- a/lib/chef/provisioning/google_driver/client/metadata.rb
+++ b/lib/chef/provisioning/google_driver/client/metadata.rb
@@ -80,7 +80,8 @@ class Chef
 
           # Gets one metadata item with the given key.
           def get_metadata_item(key)
-            @items.find { |item| item[:key] == key }[:value]
+            match = @items.find { |item| item[:key] == key }
+            match[:value] if match
           end
 
           SSH_KEYS = "sshKeys"

--- a/lib/chef/resource/google_key_pair.rb
+++ b/lib/chef/resource/google_key_pair.rb
@@ -1,11 +1,6 @@
 require "chef/resource/lwrp_base"
 
 class Chef::Resource::GoogleKeyPair < Chef::Resource::LWRPBase
-  self.resource_name = self.dsl_name
-
-  # TODO instance specific or project wide?
-  # Right now we only have project wide keys
-
   provides :google_key_pair
 
   actions :create, :destroy


### PR DESCRIPTION
Clean up warning messages,

```
* This will no longer work in Chef 13: you must use 'provides' to use the resource's DSL.
* Resource.dsl_name is deprecated and will be removed in Chef 13.
```

And fix a bug when there were no existing ssh keys or metadata tracking.